### PR TITLE
wasm-sdk: fix setting rodata and bss section variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The wasm-bpf runtime require two parts: `the host side`(Outside the Wasm runtime
   - see [src](src) and [include](include) directories, which would be a sample runtime built on the top of [libbpf](https://github.com/libbpf/libbpf) and [WAMR](https://github.com/bytecodealliance/wasm-micro-runtime).
   - You can easily build your own Wasm-eBPF runtime in `any` languages, `any` eBPF libraries and `any` Wasm runtimes with the same System interface.
 - wasm side: toolchains and libraries
-  - a [`libbpf-wasm`](wasm-include/libbpf-wasm.h) header only library to provide libbpf APIs for Wasm guest `C/C++` code.
+  - a [`libbpf-wasm`](wasm-sdk/libbpf-wasm.h) header only library to provide libbpf APIs for Wasm guest `C/C++` code.
   - a [`bpftool`](https://github.com/eunomia-bpf/bpftool/tree/wasm-bpftool) tool to generate the Wasm-eBPF `skeleton` headers, and `C struct definitions` for passing data between the host and Wasm guest without serialization.
   - More languages support(`Rust`, `Go`, etc) is on the way.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -17,7 +17,7 @@
 - host 侧: 见 [src](src) 以及 [include](include) 文件夹。 主机侧是一个构建在 [libbpf](https://github.com/libbpf/libbpf) 和 [WAMR](https://github.com/bytecodealliance/wasm-micro-runtime) 之上的运行时。
   - 使用同一套工具链，任何人用任何 wasm 运行时或者任何 ebpf 用户态库，以及任何语言，都可以在两三百行三四百行内轻松实现一套 wasm+ebpf 运行时平台，运行几乎所有的 ebpf 应用场景。
 - wasm 侧:
-  - 一个用于给 Wasm 客户侧 `C/C++` 代码提供 libbpf API的头文件库([`libbpf-wasm`](wasm-include/libbpf-wasm.h))。
+  - 一个用于给 Wasm 客户侧 `C/C++` 代码提供 libbpf API的头文件库([`libbpf-wasm`](wasm-sdk/libbpf-wasm.h))。
   - 一个用来生成 Wasm-eBPF `skeleton` 头文件以及生成用于在主机侧和 Wasm 客户侧传递数据的 C 结构体定义的 [`bpftool`](https://github.com/eunomia-bpf/bpftool/tree/wasm-bpftool)。
   - 更多编程语言支持(比如 `Rust`、 `Go` 等)还在开发中。
 

--- a/examples/bootstrap/README.md
+++ b/examples/bootstrap/README.md
@@ -135,7 +135,7 @@ This would invoke the following steps:
   >
   > We have create a specical POC tool outside of `bpftool` for generate C structs serialization-free bindings between eBPF/host side and Wasm, you can find it in [c-struct-bindgen](https://github.com/eunomia-bpf/c-struct-bindgen). More details about how to deal with the struct layout issue can be found in the README of the c-struct-bindgen tool.
 
-  The libbpf API for wasm program is provided as an header only library, you can find it in `libbpf-wasm.h` (wasm-include/libbpf-wasm.h). The wasm program can use the libbpf API and syscall to operate the BPF object, for example:
+  The libbpf API for wasm program is provided as an header only library, you can find it in [`libbpf-wasm.h`](../../wasm-sdk/libbpf-wasm.h). The wasm program can use the libbpf API and syscall to operate the BPF object, for example:
 
     ```c
     /* Load and verify BPF application */

--- a/examples/bootstrap/README_zh.md
+++ b/examples/bootstrap/README_zh.md
@@ -120,7 +120,7 @@ make
   >
   >我们创建了一个特殊的 POC 工具，它不属于 `bpftool`，可以生成 eBPF/主机端和 Wasm 之间的不需要序列化的 C 结构体绑定，您可以在 [c-struct-bindgen](https://github.com/eunomia-bpf/c-struct-bindgen) 中找到它。关于如何处理结构体布局问题的更多详细信息，可以在 c-struct-bindgen 工具的 README 中找到。
 
-libbpf API 为 wasm 程序提供了一个仅包含头文件的库，您可以在 libbpf-wasm.h（wasm-include/libbpf-wasm.h）中找到它。wasm 程序可以使用 libbpf API 和 syscall 操作 BPF 对象，例如：
+libbpf API 为 wasm 程序提供了一个仅包含头文件的库，您可以在 [libbpf-wasm](../../wasm-sdk/libbpf-wasm.h) 中找到它。wasm 程序可以使用 libbpf API 和 syscall 操作 BPF 对象，例如：
 
 ```c
 /* Load and verify BPF application */

--- a/examples/bootstrap/bootstrap.c
+++ b/examples/bootstrap/bootstrap.c
@@ -63,6 +63,8 @@ main(int argc, char **argv)
     struct bpf_buffer *rb = NULL;
     struct bootstrap_bpf *skel;
     int err;
+
+	// parse the args manually for demo purpose
     if (argc > 3 || strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0) {
         print_usage();
         return 0;

--- a/examples/runqlat/runqlat.c
+++ b/examples/runqlat/runqlat.c
@@ -28,7 +28,7 @@ struct env {
 	char *cgroupspath;
 	bool cg;
 } env = {
-	.interval = 99999999,
+	.interval = 1,
 	.times = 99999999,
 };
 
@@ -45,7 +45,6 @@ const char argp_program_doc[] =
 "EXAMPLES:\n"
 "    runqlat         # summarize run queue latency as a histogram\n"
 "    runqlat 1 10    # print 1 second summaries, 10 times\n"
-"    runqlat -mT 1   # 1s summaries, milliseconds, and timestamps\n"
 "    runqlat -P      # show each PID separately\n"
 "    runqlat -p 185  # trace PID 185 only\n"
 "    runqlat -c CG   # Trace process under cgroupsPath CG\n";
@@ -108,12 +107,14 @@ int main(int argc, char **argv)
 	int err;
 	int idx, cg_map_fd;
 	int cgfd = -1;
-
+	
+	// parse the args manually for demo purpose
     if (argc > 3 || strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "--help") == 0) {
         print_usage();
         return 0;
-    }
-    if (argc == 3) {
+    } else if (argc == 2 && strcmp(argv[1], "-P")) {
+		env.per_process = true;
+	} else if (argc == 3) {
         env.interval = atoi(argv[1]);
         env.times = atoi(argv[2]);
     } else if (argc == 2) {


### PR DESCRIPTION
## Description

Fix setting rodata and bss section variables:
```console
$ sudo /home/yunwei/wasm-bpf/build/bin/Release/wasm-bpf /home/yunwei/wasm-bpf/examples/bootstrap/bootstrap.wasm -d 100
TIME     EVENT COMM             PID     PPID    FILENAME/EXIT CODE
18:32:41 EXIT  sleep            106551  106545  [0] (1001ms)
18:32:41 EXIT  cpuUsage.sh      106545  106544  [0] (1016ms)
18:32:41 EXIT  sh               106544  1997    [0] (1016ms)
18:32:46 EXIT  sleep            106572  106566  [0] (1001ms)
18:32:46 EXIT  cpuUsage.sh      106566  106565  [0] (1020ms)
18:32:46 EXIT  sh               106565  1997    [0] (1021ms)
18:32:51 EXIT  sleep            106598  106591  [0] (1001ms)
18:32:51 EXIT  cpuUsage.sh      106591  106590  [0] (1011ms)
18:32:51 EXIT  sh               106590  1997    [0] (1012ms)
```
## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
