### PR TITLE
extern wasm_main to C

### DIFF
--- a/include/bpf-api.h
+++ b/include/bpf-api.h
@@ -62,7 +62,8 @@ enum bpf_map_cmd {
 /// Operate on a bpf map.
 int bpf_map_operate(int fd, int cmd, void *key, void *value, void *next_key,
                     uint64_t flags);
+extern "C" {
 /// The main entry, argc and argv will be passed to the wasm module.
 int wasm_main(unsigned char *buf, unsigned int size, int argc, char *argv[]);
-
+}
 #endif


### PR DESCRIPTION
Use extern "C" to tell the compiler to use the C language naming convention to resolve wasm_main, avoiding ecli-rs build errors