### PR TITLE
[runtime] format and cleanup rust code

### DIFF
--- a/runtime/rust/src/func/attach.rs
+++ b/runtime/rust/src/func/attach.rs
@@ -6,6 +6,7 @@ use crate::{ensure_c_str, ensure_program_mut_by_state, state::CallerType};
 
 use super::{BpfObjectType, WasmString};
 
+// attach a bpf program to hook points
 pub fn wasm_attach_bpf_program(
     mut caller: CallerType,
     program: BpfObjectType,

--- a/runtime/rust/src/func/close.rs
+++ b/runtime/rust/src/func/close.rs
@@ -6,6 +6,7 @@ use crate::state::CallerType;
 
 use super::BpfObjectType;
 
+/// close and detach a bpf object
 pub fn wasm_close_bpf_object(mut caller: CallerType, program: BpfObjectType) -> i32 {
     debug!("Close bpf object: {}", program);
     let state = caller.data_mut();

--- a/runtime/rust/src/func/fd_by_name.rs
+++ b/runtime/rust/src/func/fd_by_name.rs
@@ -1,9 +1,10 @@
 use log::debug;
 
-use crate::{state::CallerType, ensure_c_str, ensure_program_mut_by_caller};
+use crate::{ensure_c_str, ensure_program_mut_by_caller, state::CallerType};
 
 use super::{BpfObjectType, WasmString};
 
+/// get map fd by name from a bpf object
 pub fn wasm_bpf_map_fd_by_name(
     mut caller: CallerType,
     program: BpfObjectType,

--- a/runtime/rust/src/func/load.rs
+++ b/runtime/rust/src/func/load.rs
@@ -8,6 +8,7 @@ use crate::{
 
 use super::WasmPointer;
 
+/// load a bpf object from memory into the kernel
 pub fn wasm_load_bpf_object(
     mut caller: CallerType,
     obj_buf: WasmPointer,

--- a/runtime/rust/src/func/map_operate.rs
+++ b/runtime/rust/src/func/map_operate.rs
@@ -1,7 +1,16 @@
-use libbpf_rs::libbpf_sys::{bpf_map_get_next_key, bpf_map_lookup_elem_flags, bpf_map_update_elem, bpf_map_delete_elem_flags, BPF_MAP_GET_NEXT_KEY, BPF_MAP_LOOKUP_ELEM, BPF_MAP_UPDATE_ELEM, BPF_MAP_DELETE_ELEM};
+use libbpf_rs::libbpf_sys::{
+    bpf_map_delete_elem_flags, bpf_map_get_next_key, bpf_map_lookup_elem_flags,
+    bpf_map_update_elem, BPF_MAP_DELETE_ELEM, BPF_MAP_GET_NEXT_KEY, BPF_MAP_LOOKUP_ELEM,
+    BPF_MAP_UPDATE_ELEM,
+};
 use log::debug;
 
-use crate::{state::CallerType, func::{ENOENT, EINVAL}, ensure_enough_memory, utils::CallerUtils};
+use crate::{
+    ensure_enough_memory,
+    func::{EINVAL, ENOENT},
+    state::CallerType,
+    utils::CallerUtils,
+};
 
 use super::WasmPointer;
 

--- a/runtime/rust/src/func/mod.rs
+++ b/runtime/rust/src/func/mod.rs
@@ -1,13 +1,12 @@
-
 pub const EINVAL: i32 = 22;
 pub const ENOENT: i32 = 2;
 
-pub mod poll;
-pub mod load;
-pub mod close;
 pub mod attach;
+pub mod close;
 pub mod fd_by_name;
+pub mod load;
 pub mod map_operate;
+pub mod poll;
 pub mod wrapper_poll;
 #[macro_export]
 macro_rules! ensure_program_mut_by_state {
@@ -23,34 +22,29 @@ macro_rules! ensure_program_mut_by_state {
 }
 #[macro_export]
 macro_rules! ensure_program_mut_by_caller {
-    ($caller: expr, $program: expr) => {
-        {
-            use $crate::ensure_program_mut_by_state;
-            ensure_program_mut_by_state!($caller.data_mut(), $program)
-        }
-    };
+    ($caller: expr, $program: expr) => {{
+        use $crate::ensure_program_mut_by_state;
+        ensure_program_mut_by_state!($caller.data_mut(), $program)
+    }};
 }
 
 #[macro_export]
 macro_rules! ensure_c_str {
-    ($caller: expr, $var_name: expr) => {
-        {
-            use $crate::utils::CallerUtils;   
-            match $caller.read_zero_terminated_str($var_name as usize) {
-                Ok(v) => v.to_string(),
-                Err(err) => {
-                    log::debug!("Failed to read `{}`: {}", stringify!($var_name), err);
-                    return -1;
-                }
+    ($caller: expr, $var_name: expr) => {{
+        use $crate::utils::CallerUtils;
+        match $caller.read_zero_terminated_str($var_name as usize) {
+            Ok(v) => v.to_string(),
+            Err(err) => {
+                log::debug!("Failed to read `{}`: {}", stringify!($var_name), err);
+                return -1;
             }
         }
-    };
+    }};
 }
 
 pub type WasmPointer = u32;
 pub type BpfObjectType = u64;
 pub type WasmString = u32;
-
 
 #[macro_export]
 macro_rules! ensure_enough_memory {

--- a/runtime/rust/src/func/poll.rs
+++ b/runtime/rust/src/func/poll.rs
@@ -165,7 +165,6 @@ impl BufferInnerType {
 pub struct BpfBuffer {
     pub events: *mut bpf_map,
     pub inner: BufferInnerType,
-    // pub host_ctx: *mut c_void,
     pub map_type: bpf_map_type,
     pub host_sample_fn: Option<SampleCallbackWrapper>,
     pub wasm_sample_fn: u32,

--- a/runtime/rust/src/func/wrapper_poll.rs
+++ b/runtime/rust/src/func/wrapper_poll.rs
@@ -13,30 +13,9 @@ pub fn bpf_buffer_poll_wrapper(
     max_size: i32,
     timeout_ms: i32,
 ) -> i32 {
-    // let callback_func_name = match caller.data().poll_wrapper {
-    //     PollWrapper::Disabled => {
-    //         panic!("Something terrible happened. bpf_buffer_poll_wrapper must be called with poll_wrapper=PollWrapper::Enabled{{}}");
-    //     }
-    //     PollWrapper::Enabled {
-    //         ref callback_function_name,
-    //     } => callback_function_name.clone(),
-    // };
     let callback_func_name = caller.data().callback_func_name.clone();
     caller.data_mut().wrapper_called = true;
     if let Some(export) = caller.get_export(&callback_func_name) {
-        // if let Some(func) = export.into_func() {
-        //     if let Err(err) = func.typed::<SampleCallbackParams, SampleCallbackReturn>(&mut caller)
-        //     {
-        //         error!(
-        //             "Invalid function signature for {}, expected func(u32, u32, u32) -> u32: {}",
-        //             callback_func_name, err
-        //         );
-        //         return EINVAL;
-        //     }
-        // } else {
-        //     error!("Export {} is not func", callback_func_name);
-        //     return EINVAL;
-        // }
         if export.into_func().is_none() {
             error!("Export {} is not func", callback_func_name);
             return EINVAL;

--- a/runtime/rust/src/main.rs
+++ b/runtime/rust/src/main.rs
@@ -31,8 +31,6 @@ struct CommandArgs {
     wasm_module_file: String,
     #[arg(long, help = "Display more logs")]
     verbose: bool,
-    // #[arg(short = 'w', long, help = "Enable polyfill wrapper")]
-    // enable_wrapper: bool,
     #[arg(short = 'm', long, help = "Wrapper module name", default_value_t = String::from("callback-wrapper"))]
     wrapper_module_name: String,
     #[arg(short = 'c', long, help = "Callback export name", default_value_t = String::from("go-callback"))]
@@ -78,10 +76,6 @@ fn main() -> anyhow::Result<()> {
         wrapper_poll::bpf_buffer_poll_wrapper,
         POLL_WRAPPER_FUNCTION_NAME
     )?;
-    // store.data_mut().poll_wrapper = PollWrapper::Enabled {
-    //     callback_function_name: args.callback_export_name,
-    // };
-    // linker.
     linker
         .module(&mut store, MAIN_MODULE_NAME, &main_module)
         .with_context(|| anyhow!("Failed to link main module"))?;

--- a/runtime/rust/src/utils.rs
+++ b/runtime/rust/src/utils.rs
@@ -1,6 +1,6 @@
 use std::ffi::CStr;
 
-use crate::{AppState, state::CallerType};
+use crate::{state::CallerType, AppState};
 use anyhow::{anyhow, bail, Context};
 use wasmtime::{Caller, Memory, Table, WasmParams, WasmResults};
 
@@ -136,7 +136,6 @@ impl FunctionQuickCall for CallerType<'_> {
     }
 }
 
-
 #[macro_export]
 macro_rules! add_bind_function_with_module_and_name {
     ($linker: expr, $module: expr, $func: expr, $name: expr) => {{
@@ -150,10 +149,9 @@ macro_rules! add_bind_function_with_module_and_name {
 #[macro_export]
 macro_rules! add_bind_function_with_module {
     ($linker: expr, $module: expr, $func: expr) => {
-        add_bind_function_with_module_and_name!($linker, $module, $func , stringify!($func))
+        add_bind_function_with_module_and_name!($linker, $module, $func, stringify!($func))
     };
 }
-
 
 #[macro_export]
 macro_rules! add_bind_function {
@@ -161,5 +159,3 @@ macro_rules! add_bind_function {
         add_bind_function_with_module!($linker, "wasm_bpf", $func)
     };
 }
-
-


### PR DESCRIPTION
## Description

A lot of rust code has unnecessary comments and unformatted. This patch fix this.
