### PR TITLE
Make cpp runtime example better

### DIFF
--- a/runtime/cpp/include/bpf-api.h
+++ b/runtime/cpp/include/bpf-api.h
@@ -2,10 +2,9 @@
  *
  * Copyright (c) 2023, eunomia-bpf
  * All rights reserved.
+ *
+ * This is a minimal working example of wasm-bpf runtime implementation.
  */
-// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
-/* Copyright (c) 2022 Hengqi Chen */
-
 #ifndef __BPF_WASM_API_H
 #define __BPF_WASM_API_H
 
@@ -31,19 +30,20 @@ int bpf_link__destroy(struct bpf_link *link);
 
 /// @brief init libbpf callbacks
 void init_libbpf(void);
-struct wasm_bpf_program {
+/// @brief bpf program instance
+class wasm_bpf_program {
     std::unique_ptr<bpf_object, void (*)(bpf_object *obj)> obj{
         nullptr, bpf_object__close};
     std::unique_ptr<bpf_buffer, void (*)(bpf_buffer *obj)> buffer{
         nullptr, bpf_buffer__free};
     std::unordered_set<std::unique_ptr<bpf_link, int (*)(bpf_link *obj)>> links;
-    void *poll_data;
-    size_t max_poll_size;
+
+   public:
     int bpf_map_fd_by_name(const char *name);
     int load_bpf_object(const void *obj_buf, size_t obj_buf_sz);
     int attach_bpf_program(const char *name, const char *attach_target);
     int bpf_buffer_poll(wasm_exec_env_t exec_env, int fd, int32_t sample_func,
-                        uint32_t ctx, void *data, size_t max_size,
+                        uint32_t ctx, void *buffer_data, size_t max_size,
                         int timeout_ms);
 };
 
@@ -60,4 +60,5 @@ extern "C" {
 /// The main entry, argc and argv will be passed to the wasm module.
 int wasm_main(unsigned char *buf, unsigned int size, int argc, char *argv[]);
 }
+
 #endif

--- a/runtime/cpp/include/bpf-api.h
+++ b/runtime/cpp/include/bpf-api.h
@@ -19,11 +19,9 @@
 #define DEBUG_LIBBPF_RUNTIME 0
 
 extern "C" {
-struct bpf_buffer;
 struct bpf_map;
 struct bpf_object;
 struct bpf_link;
-void bpf_buffer__free(struct bpf_buffer *);
 void bpf_object__close(struct bpf_object *object);
 int bpf_link__destroy(struct bpf_link *link);
 }
@@ -34,8 +32,7 @@ void init_libbpf(void);
 class wasm_bpf_program {
     std::unique_ptr<bpf_object, void (*)(bpf_object *obj)> obj{
         nullptr, bpf_object__close};
-    std::unique_ptr<bpf_buffer, void (*)(bpf_buffer *obj)> buffer{
-        nullptr, bpf_buffer__free};
+    std::unique_ptr<bpf_buffer> buffer;
     std::unordered_set<std::unique_ptr<bpf_link, int (*)(bpf_link *obj)>> links;
 
    public:

--- a/runtime/cpp/test/src/bpf_api_test.cpp
+++ b/runtime/cpp/test/src/bpf_api_test.cpp
@@ -1,9 +1,8 @@
 /* SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
  *
- * Copyright (c) 2022, zys
+ * Copyright (c) 2023, eunomia-bpf org
  * All rights reserved.
  */
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
The C++ runtime example is not clear and clean. This PR fix it.