### PR TITLE
ci: avoid run some test on fork

### DIFF
--- a/.github/workflows/deploy-asserts.yml
+++ b/.github/workflows/deploy-asserts.yml
@@ -51,11 +51,14 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v1
+        if: ${{ github.repository_owner == 'eunomia-bpf' }}
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
+        if: ${{ github.repository_owner == 'eunomia-bpf' }}
         with:
           # Upload entire repository
           path: '.'
       - name: Deploy to GitHub Pages
+        if: ${{ github.repository_owner == 'eunomia-bpf' }}
         id: deploymen
         uses: actions/deploy-pages@main

--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -25,6 +25,7 @@ jobs:
 
       - name: Login to Github Packages
         uses: docker/login-action@v2
+        if: ${{ github.repository_owner == 'eunomia-bpf' }}
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -36,6 +37,7 @@ jobs:
 
       - name: Build wasm-bpf image and push to GitHub Container Registry
         uses: docker/build-push-action@v2
+        if: ${{ github.repository_owner == 'eunomia-bpf' }}
         with:
           # relative path to the place where source code with Dockerfile is located
           context: ./

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,7 @@ jobs:
       run:  cd runtime/wasm-bpf-rs && make test
     - name: Upload analysis results to GitHub
       uses: github/codeql-action/upload-sarif@v2
+      if: ${{ github.repository_owner == 'eunomia-bpf' }}
       with:
         sarif_file: runtime/wasm-bpf-rs/rust-clippy-results.sarif
         wait-for-processing: true


### PR DESCRIPTION
Adding run rules to avoid running unpassable tests on the fork, solve the nuisance of users not being able to pass tests.