### PR TITLE
add nix flake support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,30 @@
+name: "nix-test"
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3.3.0
+    - uses: nixbuild/nix-quick-install-action@v22
+      with:
+        nix_conf: |
+          experimental-features = nix-command flakes
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+    - uses: cachix/cachix-action@v12
+      with:
+        name: zeek
+
+    - name: Nix Flake Show
+      run: nix flake show --all-systems
+
+    - name: Check nix develop
+      run: nix develop
+
+    - name: Build wasm-bpf
+      run: nix build .#wasm-bpf

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+.direnv
 .vscode/
 build/
+result/
 examples/wasm-bpf
 wasi-sdk-*-linux.tar.gz
 tinygo_0.27.0_amd64.deb

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .direnv
 .vscode/
 build/
-result/
+result
 examples/wasm-bpf
 wasi-sdk-*-linux.tar.gz
 tinygo_0.27.0_amd64.deb

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ See the [examples](examples) directory for examples of eBPF programs written in 
 - [lsm](examples/lsm) and  [go-lsm](examples/go-lsm): check the permission to remove a directory
 
 `networking example`
-- [sockfilter](examples/sockfilter): monitoring packet and dealing with __sk_buff.
+- [sockfilter](examples/sockfilter): monitoring packet and dealing with `__sk_buff`.
 - [sockops](examples/sockops): Add the pid int tcp option in syn packet.
 
 ## How it works
@@ -135,6 +135,13 @@ We have two types of runtime samples:
 - A Rust runtime example, which is a more complex runtime based on Wasmtime. see [runtime/wasm-bpf-rs](../runtime/wasm-bpf-rs) for more details.
 
 The runtime can be built as a library or a standalone executable. see [docs/build.md](docs/build.md) to build the runtimes.
+
+### Use Nix
+
+This project has nix flake and direnv support.
+See:
+- [direnv](https://github.com/direnv/direnv)
+- [Nix](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix.html)
 
 ## LICENSE
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,102 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1679638953,
+        "narHash": "sha256-OFATLLft/9vXHf+zqa6OQGTQ2rrCuD97KRzsrPsJRdY=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "1336152ce31c0f781ae121aa297a5699c642a9fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1679567394,
+        "narHash": "sha256-ZvLuzPeARDLiQUt6zSZFGOs+HZmE+3g4QURc8mkBsfM=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "88cd22380154a2c36799fe8098888f0f59861a15",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1679437018,
+        "narHash": "sha256-vOuiDPLHSEo/7NkiWtxpHpHgoXoNmrm+wkXZ6a072Fc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "19cf008bb18e47b6e3b4e16e32a9a4bdd4b45f7e",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1679520343,
+        "narHash": "sha256-AJGSGWRfoKWD5IVTu1wEsR990wHbX0kIaolPqNMEh0c=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "eb791f31e688ae00908eb75d4c704ef60c430a92",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,69 @@
+{
+  description = "wasm-bpf packages and dev shell flake";
+
+  outputs =
+    { self
+    , fenix
+    , flake-utils
+    , naersk
+    , nixpkgs
+    }:
+    flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = nixpkgs.legacyPackages.${system};
+      toolchain = with fenix.packages.${system}; combine [
+        minimal.cargo
+        minimal.rustc
+      ];
+      fenix-naersk = naersk.lib.${system}.override {
+        cargo = toolchain;
+        rustc = toolchain;
+      };
+    in
+    {
+      packages = rec {
+        wasm-bpf = fenix-naersk.buildPackage {
+          hardeningDisable = [ "all" ];
+          buildInputs = with pkgs; [
+            zlib
+          ];
+          nativeBuildInputs = with pkgs; [
+            clang
+            elfutils
+            pkg-config
+          ];
+          src = ./runtime;
+        };
+
+        default = wasm-bpf;
+      };
+
+      devShell = pkgs.mkShell {
+        buildInputs = with pkgs; [
+          toolchain
+          zlib
+          openssl
+        ];
+        nativeBuildInputs = with pkgs; [
+          clang
+          elfutils
+          pkg-config
+        ];
+      };
+    }
+    );
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flake-utils.url = "github:numtide/flake-utils";
+    naersk = {
+      url = "github:nix-community/naersk";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+}
+

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,9 @@
     {
       packages = rec {
         wasm-bpf = fenix-naersk.buildPackage {
+          pname = "wasm-bpf";
           hardeningDisable = [ "all" ];
+          cargoBuildOptions = x: x ++ [ "-p" "wasm-bpf" ];
           buildInputs = with pkgs; [
             zlib
           ];


### PR DESCRIPTION
Add support for nix flake and direnv, including devShell and package wasm-bpf.
Part of https://github.com/eunomia-bpf/eunomia-bpf/issues/158

<details>
<summary> result: nix run .#wasm-bpf </summary>

```sh
-> nix run .#wasm-bpf
error: the following required arguments were not provided:
  <WASM_MODULE_FILE>

Usage: wasm-bpf <WASM_MODULE_FILE> [ARGS_TO_WASM]...

For more information, try '--help'.
```
</details>