### PR TITLE
Bump  `libbpf-rs`  to 0.20.1

### DIFF
--- a/examples/xdp/xdp.bpf.c
+++ b/examples/xdp/xdp.bpf.c
@@ -2,13 +2,13 @@
 #include <bpf/bpf_helpers.h>
 
 SEC("xdp")
-int xdp_pass(struct xdp_md *ctx) {
-	void *data = (void *)(long)ctx->data;
-	void *data_end = (void *)(long)ctx->data_end;
-	int pkt_sz = data_end - data;
+int xdp_pass(struct xdp_md* ctx) {
+    void* data = (void*)(long)ctx->data;
+    void* data_end = (void*)(long)ctx->data_end;
+    int pkt_sz = data_end - data;
 
-	bpf_printk("packet size: %d\n", pkt_sz);
-	return XDP_PASS;
+    bpf_printk("packet size: %d\n", pkt_sz);
+    return XDP_PASS;
 }
 
 char __license[] SEC("license") = "GPL";

--- a/examples/xdp/xdp.c
+++ b/examples/xdp/xdp.c
@@ -7,7 +7,7 @@
 int main(int argc, char* argv[]) {
     struct xdp_bpf* skel = NULL;
     int err;
-    
+
     skel = xdp_bpf__open_and_load();
     if (!skel) {
         printf("Failed to open and load BPF skeleton\n");

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+
+[[package]]
 name = "addr2line"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,6 +51,12 @@ checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
 name = "ambient-authority"
@@ -916,9 +928,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libbpf-rs"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8754dada215ff440a315ac4251f18005a89d6d6005859ef58e101f8696a19e73"
+checksum = "6c1401b366ec96859ef47e68a26f6b9e7cc2f241fafd8c844eba50033bf548b3"
 dependencies = [
  "bitflags",
  "lazy_static",
@@ -1141,6 +1153,29 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
+name = "ouroboros"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1358bd1558bd2a083fed428ffeda486fbfb323e698cdda7794259d592ca72db"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
+dependencies = [
+ "Inflector",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "overload"
@@ -1807,6 +1842,7 @@ dependencies = [
  "flexi_logger",
  "libbpf-rs",
  "log",
+ "ouroboros",
  "wasi-common",
  "wasmtime",
  "wasmtime-wasi",

--- a/runtime/cpp/src/wasm-bpf.cpp
+++ b/runtime/cpp/src/wasm-bpf.cpp
@@ -206,10 +206,9 @@ static int attach_xdp(struct bpf_program* prog, const char* argv) {
         printf("Failed to find network interface %s\n", argv);
         return -1;
     }
-    if(!bpf_program__attach_xdp(prog, ifindex)) {
+    if (!bpf_program__attach_xdp(prog, ifindex)) {
         printf("Prog %s failed to attach network interface %s\n",
-               bpf_program__name(prog),
-               argv);
+               bpf_program__name(prog), argv);
         return -1;
     }
     return 0;

--- a/runtime/wasm-bpf-rs/Cargo.toml
+++ b/runtime/wasm-bpf-rs/Cargo.toml
@@ -11,9 +11,10 @@ repository = "https://github.com/eunomia-bpf/wasm-bpf"
 [dependencies]
 anyhow = { version = "1.0.69",  features = ["backtrace"] }
 flexi_logger = "0.25.1"
-libbpf-rs = "0.20.0"
+libbpf-rs = "0.20.1"
 log = "0.4.17"
 wasmtime = "5.0.1"
 wasmtime-wasi = "5.0.0"
 wasi-common = "5.0.0"
 wiggle = "5.0.1"
+ouroboros = "0.15.6"

--- a/runtime/wasm-bpf-rs/src/bpf/attach.rs
+++ b/runtime/wasm-bpf-rs/src/bpf/attach.rs
@@ -28,8 +28,8 @@ pub fn wasm_attach_bpf_program(
     };
     let state = caller.data_mut();
     let object = ensure_program_mut_by_state!(state, program);
-
-    let program = match object.get_object_mut().prog_mut(&name_str) {
+    let mut object_guard = object.get_object_mut();
+    let program = match object_guard.prog_mut(&name_str) {
         Some(v) => v,
         None => {
             debug!("No program named `{}` found", name_str);

--- a/runtime/wasm-bpf-rs/src/bpf/fd_by_name.rs
+++ b/runtime/wasm-bpf-rs/src/bpf/fd_by_name.rs
@@ -18,8 +18,8 @@ pub fn wasm_bpf_map_fd_by_name(
     debug!("map fd by name");
     let map_name = ensure_c_str!(caller, name);
     let object = ensure_program_mut_by_caller!(caller, program);
-
-    let map = match object.get_object().map(&map_name) {
+    let object_guard = object.get_object();
+    let map = match object_guard.map(&map_name) {
         Some(v) => v,
         None => {
             debug!("Invalid map name: {}", map_name);

--- a/runtime/wasm-bpf-rs/src/bpf/load.rs
+++ b/runtime/wasm-bpf-rs/src/bpf/load.rs
@@ -3,6 +3,8 @@
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.
 //!
+use std::{cell::RefCell, rc::Rc};
+
 use libbpf_rs::ObjectBuilder;
 use log::debug;
 
@@ -56,8 +58,8 @@ pub fn wasm_load_bpf_object(
     state.object_map.insert(
         next_id,
         WrapperObject {
-            object,
-            buffer: None,
+            object: Rc::new(RefCell::new(object)),
+            poll_buffer: None,
         },
     );
     debug!("Load bpf object done, id={}", next_id);

--- a/runtime/wasm-bpf-rs/src/bpf/map_operate.rs
+++ b/runtime/wasm-bpf-rs/src/bpf/map_operate.rs
@@ -3,36 +3,21 @@
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.
 //!
-use std::os::raw::c_void;
+use std::os::fd::BorrowedFd;
 
-use libbpf_rs::libbpf_sys::{
-    bpf_map_delete_elem_flags, bpf_map_get_next_key, bpf_map_info, bpf_map_lookup_elem_flags,
-    bpf_map_update_elem, bpf_obj_get_info_by_fd, BPF_MAP_DELETE_ELEM, BPF_MAP_GET_NEXT_KEY,
-    BPF_MAP_LOOKUP_ELEM, BPF_MAP_UPDATE_ELEM,
+use libbpf_rs::{
+    libbpf_sys::{
+        bpf_map_delete_elem_flags, bpf_map_get_next_key, bpf_map_lookup_elem_flags,
+        bpf_map_update_elem, BPF_MAP_DELETE_ELEM, BPF_MAP_GET_NEXT_KEY, BPF_MAP_LOOKUP_ELEM,
+        BPF_MAP_UPDATE_ELEM,
+    },
+    MapInfo,
 };
 use log::{debug, error};
 
 use crate::{bpf::EINVAL, ensure_enough_memory, state::CallerType, utils::CallerUtils};
 
 use super::WasmPointer;
-
-/// get map info for map key value size and types
-fn get_map_info(fd: i32) -> Result<bpf_map_info, i32> {
-    let mut map_info = unsafe { std::mem::zeroed::<bpf_map_info>() };
-    let mut info_len: u32 = std::mem::size_of::<bpf_map_info>() as u32;
-    let ret = unsafe {
-        bpf_obj_get_info_by_fd(
-            fd,
-            &mut map_info as *mut bpf_map_info as *mut c_void,
-            &mut info_len,
-        )
-    };
-    if ret != 0 {
-        error!("Failed to get map info: {}", ret);
-        return Err(ret);
-    }
-    Ok(map_info)
-}
 
 /// map operate, used for map update, lookup, delete, get_next_key
 pub fn wasm_bpf_map_operate(
@@ -49,17 +34,25 @@ pub fn wasm_bpf_map_operate(
         fd, cmd, key, value, next_key, flags
     );
     let (key_size, value_size) = {
-        let map_info = match get_map_info(fd) {
+        // SAFETY: The fd is only used to query map info, which will not be used to write or read
+        let map_info = match MapInfo::new(unsafe { BorrowedFd::borrow_raw(fd) }) {
             Ok(v) => v,
-            Err(err) => return err,
+            Err(err) => {
+                error!("Failed to get MapInfo: {}", err);
+                return -1;
+            }
         };
-        (map_info.key_size as usize, map_info.value_size as usize)
+        (
+            map_info.info.key_size as usize,
+            map_info.info.value_size as usize,
+        )
     };
 
     match cmd as u32 {
         BPF_MAP_GET_NEXT_KEY => {
             ensure_enough_memory!(caller, key, key_size, EINVAL);
             ensure_enough_memory!(caller, next_key, key_size, EINVAL);
+            // SAFETY: memory addresses are checked to be valid
             let ret_val = unsafe {
                 bpf_map_get_next_key(
                     fd,
@@ -75,6 +68,7 @@ pub fn wasm_bpf_map_operate(
         BPF_MAP_LOOKUP_ELEM => {
             ensure_enough_memory!(caller, key, key_size, EINVAL);
             ensure_enough_memory!(caller, value, value_size, EINVAL);
+            // SAFETY: memory addresses are checked to be valid
             let ret_val = unsafe {
                 bpf_map_lookup_elem_flags(
                     fd,
@@ -91,6 +85,7 @@ pub fn wasm_bpf_map_operate(
         BPF_MAP_UPDATE_ELEM => {
             ensure_enough_memory!(caller, key, key_size, EINVAL);
             ensure_enough_memory!(caller, value, value_size, EINVAL);
+            // SAFETY: memory addresses are checked to be valid
             let ret_val = unsafe {
                 bpf_map_update_elem(
                     fd,
@@ -106,6 +101,7 @@ pub fn wasm_bpf_map_operate(
         }
         BPF_MAP_DELETE_ELEM => {
             ensure_enough_memory!(caller, key, key_size, EINVAL);
+            // SAFETY: memory addresses are checked to be valid
             let ret_val = unsafe {
                 bpf_map_delete_elem_flags(
                     fd,
@@ -125,41 +121,4 @@ pub fn wasm_bpf_map_operate(
         }
     };
     0
-}
-
-#[cfg(test)]
-
-mod tests {
-    use libbpf_rs::ObjectBuilder;
-
-    use crate::{bpf::map_operate::get_map_info, tests::get_test_file_path};
-
-    #[test]
-    fn test_retrive_key_value_size_by_bpf_obj_get_info_by_fd() {
-        /*
-            This function tests if `bpf_obj_get_info_by_fd` corrently works.
-            Here we use `bootstrap.bpf.o` to run the test.
-            Bootstrap will create two maps.
-        */
-        let bootstrap_elf = get_test_file_path("bootstrap.bpf.o");
-        let object = ObjectBuilder::default()
-            .open_file(bootstrap_elf)
-            .unwrap()
-            .load()
-            .unwrap();
-        // Iterate over maps, call `bpf_obj_get_info_by_fd` and compare with sizes that libbpf provides
-        for map in object.maps_iter() {
-            let map_info = get_map_info(map.fd()).unwrap();
-            assert_eq!(
-                map.key_size(),
-                map_info.key_size,
-                "Different key size found"
-            );
-            assert_eq!(
-                map.value_size(),
-                map_info.value_size,
-                "Different value size found"
-            );
-        }
-    }
 }

--- a/runtime/wasm-bpf-rs/src/bpf/mod.rs
+++ b/runtime/wasm-bpf-rs/src/bpf/mod.rs
@@ -3,16 +3,16 @@
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.
 //!
-pub const EINVAL: i32 = 22;
-pub const ENOENT: i32 = 2;
+pub(crate) const EINVAL: i32 = 22;
+pub(crate) const ENOENT: i32 = 2;
 
-pub mod attach;
-pub mod close;
-pub mod fd_by_name;
-pub mod load;
-pub mod map_operate;
-pub mod poll;
-pub mod wrapper_poll;
+pub(crate) mod attach;
+pub(crate) mod close;
+pub(crate) mod fd_by_name;
+pub(crate) mod load;
+pub(crate) mod map_operate;
+pub(crate) mod poll;
+pub(crate) mod wrapper_poll;
 
 #[macro_export]
 macro_rules! ensure_program_mut_by_state {
@@ -28,10 +28,31 @@ macro_rules! ensure_program_mut_by_state {
 }
 
 #[macro_export]
+macro_rules! ensure_program_by_state {
+    ($state: expr, $program: expr) => {
+        match $state.object_map.get(&$program) {
+            Some(v) => v,
+            None => {
+                log::debug!("Invalid program: {}", $program);
+                return -1;
+            }
+        }
+    };
+}
+
+#[macro_export]
 macro_rules! ensure_program_mut_by_caller {
     ($caller: expr, $program: expr) => {{
         use $crate::ensure_program_mut_by_state;
         ensure_program_mut_by_state!($caller.data_mut(), $program)
+    }};
+}
+
+#[macro_export]
+macro_rules! ensure_program_by_caller {
+    ($caller: expr, $program: expr) => {{
+        use $crate::ensure_program_by_state;
+        ensure_program_by_state!($caller.data_mut(), $program)
     }};
 }
 

--- a/runtime/wasm-bpf-rs/src/bpf/mod.rs
+++ b/runtime/wasm-bpf-rs/src/bpf/mod.rs
@@ -69,9 +69,11 @@ macro_rules! ensure_c_str {
         }
     }};
 }
-
+/// The pointer type in 32bit wasm
 pub type WasmPointer = u32;
+/// The handle to a bpf object
 pub type BpfObjectType = u64;
+/// The string type in wasm, is also a pointer
 pub type WasmString = u32;
 
 #[macro_export]

--- a/runtime/wasm-bpf-rs/src/bpf/poll.rs
+++ b/runtime/wasm-bpf-rs/src/bpf/poll.rs
@@ -22,8 +22,8 @@ use crate::{
 
 use super::{BpfObjectType, WasmPointer};
 
-pub type SampleCallbackParams = (u32, u32, u32);
-pub type SampleCallbackReturn = i32;
+type SampleCallbackParams = (u32, u32, u32);
+type SampleCallbackReturn = i32;
 
 /// polling the bpf buffer
 ///

--- a/runtime/wasm-bpf-rs/src/bpf/poll.rs
+++ b/runtime/wasm-bpf-rs/src/bpf/poll.rs
@@ -3,115 +3,27 @@
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.
 //!
-use std::{
-    ffi::c_void,
-    ptr::{null, null_mut},
-    slice::from_raw_parts,
-};
+use std::{cell::RefCell, rc::Rc, time::Duration};
 
-use libbpf_rs::libbpf_sys::{
-    bpf_map, bpf_map__fd, bpf_map__set_autocreate, bpf_map__set_key_size, bpf_map__set_type,
-    bpf_map__set_value_size, bpf_map__type, perf_buffer, perf_buffer__free, perf_buffer__new,
-    perf_buffer__poll, ring_buffer, ring_buffer__free, ring_buffer__new, ring_buffer__poll,
-    BPF_MAP_TYPE_PERF_EVENT_ARRAY, BPF_MAP_TYPE_RINGBUF, BPF_MAP_TYPE_UNSPEC,
-};
+use anyhow::{anyhow, Result};
+use libbpf_rs::{MapType, PerfBufferBuilder, RingBufferBuilder};
 use log::{debug, error};
 use wasmtime::Val;
 
 use crate::{
     bpf::{EINVAL, ENOENT},
-    ensure_enough_memory, ensure_program_mut_by_state,
-    state::CallerType,
+    ensure_enough_memory, ensure_program_mut_by_caller, ensure_program_mut_by_state,
+    state::{
+        CallerType, PerfBufferContainerTryBuilder, PollBuffer, PollBufferImpl,
+        RingBufferContainerTryBuilder,
+    },
     utils::{CallerUtils, FunctionQuickCall},
 };
 
 use super::{BpfObjectType, WasmPointer};
 
-/// perf buffer page numbers
-pub const PERF_BUFFER_PAGES: u64 = 64;
-
-/// Context for callback function
-pub struct SampleContext {
-    /// context pass from wasm
-    pub wasm_ctx: u32,
-    /// pointer to wasm module callback function
-    pub wasm_callback_func_ptr: *mut CallerType<'static>,
-    pub callback_index: u32,
-    pub raw_wasm_data_buffer: u32,
-    pub max_size: usize,
-}
-
-impl Default for SampleContext {
-    fn default() -> Self {
-        Self {
-            wasm_ctx: u32::default(),
-            wasm_callback_func_ptr: null_mut(),
-            callback_index: u32::default(),
-            raw_wasm_data_buffer: u32::default(),
-            max_size: usize::default(),
-        }
-    }
-}
-
 pub type SampleCallbackParams = (u32, u32, u32);
 pub type SampleCallbackReturn = i32;
-pub type SampleCallbackWrapper = extern "C" fn(*mut c_void, *mut c_void, u64) -> i32;
-extern "C" fn sample_function_wrapper(ctx: *mut c_void, data: *mut c_void, size: u64) -> i32 {
-    debug!("sample_function_wrapper called");
-    let ctx = unsafe { &*(ctx as *mut SampleContext) };
-    let caller = unsafe { &mut *ctx.wasm_callback_func_ptr };
-    let available_length = ctx.max_size.min(size as usize);
-    let memory = caller.get_memory().expect("Memory must be exported");
-    if let Err(e) = memory.write(&mut *caller, ctx.raw_wasm_data_buffer as usize, unsafe {
-        from_raw_parts(data as *const u8, available_length)
-    }) {
-        error!("Failed to write wasm memory: {}", e);
-        return 0;
-    }
-    if caller.data().wrapper_called {
-        let mut result = [Val::I32(0)];
-        let callback = caller.data().callback_func_name.clone();
-        if let Err(err) = caller
-            .get_export(&callback)
-            .unwrap()
-            .into_func()
-            .unwrap()
-            .call(
-                &mut *caller,
-                &[
-                    // Seems that tinygo cannot produce unsigned integer types, so just let wasmtiime to perform the conversion
-                    Val::I32(ctx.wasm_ctx as _),
-                    Val::I32(ctx.raw_wasm_data_buffer as _),
-                    Val::I32(size as _),
-                ],
-                &mut result,
-            )
-        {
-            error!("Failed to call the callback through direct export: {}", err);
-            return -1;
-        }
-    } else {
-        match caller.perform_indirect_call::<SampleCallbackParams, SampleCallbackReturn>(
-            ctx.callback_index,
-            (ctx.wasm_ctx, ctx.raw_wasm_data_buffer, size as u32),
-        ) {
-            Ok(v) => {
-                return v;
-            }
-            Err(e) => {
-                error!(
-                    "Failed to perform indirect call when polling: {} ; {}\n{}",
-                    e.to_string(),
-                    e.root_cause(),
-                    e.backtrace()
-                );
-                return 0;
-            }
-        }
-    }
-
-    0
-}
 
 /// polling the bpf buffer
 ///
@@ -130,167 +42,174 @@ pub fn wasm_bpf_buffer_poll(
     debug!(
         "wasm_bpf_buffer_poll: program: {:?}, fd: {}, sample_func: {:?}, ctx: {:?}, data: {:?}, max_size: {}, timeout_ms: {}",
         program, fd, sample_func, ctx, data, max_size, timeout_ms);
-    let caller_ptr = &caller as *const CallerType as *mut CallerType<'static>;
     // Ensure that there is enough memory in the wasm side
     ensure_enough_memory!(caller, data, max_size, EINVAL);
-    let state = caller.data_mut();
-    let map_ptr = state.get_map_ptr_by_fd(fd);
-    let object = ensure_program_mut_by_state!(state, program);
-
-    if object.buffer.is_none() {
-        let map_ptr = match map_ptr {
-            Some(v) => v,
-            None => {
-                debug!("Invalid map fd: {}", fd);
-                return -ENOENT;
-            }
-        };
-        let mut buffer = BpfBuffer::bpf_buffer__new(map_ptr as *mut bpf_map);
-        buffer.bpf_buffer__open(sample_function_wrapper, SampleContext::default());
-        object.buffer = Some(buffer);
-    }
-    // modify the context we passed to bpf_buffer__open each time before we call bpf_buffer_poll
-    // the callback function will be called if and only if bpf_buffer__poll is called.
-    // So set the pointer to `CallerType` to the caller in the current context will work
-    let buffer = object.buffer.as_mut().unwrap();
-    let context = buffer.host_ctx_box.as_mut().unwrap();
-    context.callback_index = sample_func;
-    context.max_size = max_size as usize;
-    context.raw_wasm_data_buffer = data;
-    context.wasm_callback_func_ptr = caller_ptr;
-    context.wasm_ctx = ctx;
-    let res = buffer.bpf_buffer__poll(timeout_ms);
-    if res < 0 {
-        debug!("Failed to poll: {}", res);
-        return res;
-    }
-    0
-}
-
-/// support types for bpf buffer
-pub enum BufferInnerType {
-    /// perf buffer can be used on older kernels
-    PerfBuf(*mut perf_buffer),
-    /// ring buffer is a new feature in kernel 5.5
-    RingBuffer(*mut ring_buffer),
-    /// Unsupported
-    Unsupported,
-}
-
-impl BufferInnerType {
-    pub fn inner_ptr(&self) -> *mut c_void {
-        match self {
-            BufferInnerType::PerfBuf(s) => *s as _,
-            BufferInnerType::RingBuffer(s) => *s as _,
-            BufferInnerType::Unsupported => null_mut(),
-        }
-    }
-}
-
-/// BpfBuffer is a wrapper for perf buffer and ring buffer
-/// The real buffer types depends on the inner bpf types
-pub struct BpfBuffer {
-    map_pointer: *mut bpf_map,
-    inner: BufferInnerType,
-    host_sample_fn: Option<SampleCallbackWrapper>,
-    host_ctx_box: Option<Box<SampleContext>>,
-}
-
-#[allow(non_snake_case)]
-impl BpfBuffer {
-    /// create a new bpf buffer
-    pub fn bpf_buffer__new(map: *mut bpf_map) -> Self {
-        Self {
-            map_pointer: map,
-            inner: BufferInnerType::Unsupported,
-            host_ctx_box: None,
-            host_sample_fn: None,
-        }
-    }
-    /// get the buffer type in ring buffer or perf buffer
-    fn get_buffer_map_type(&self) -> u32 {
-        unsafe {
-            if bpf_map__type(self.map_pointer) == BPF_MAP_TYPE_RINGBUF {
-                bpf_map__set_autocreate(self.map_pointer, false);
-                BPF_MAP_TYPE_RINGBUF
-            } else if bpf_map__type(self.map_pointer) == BPF_MAP_TYPE_PERF_EVENT_ARRAY {
-                bpf_map__set_type(self.map_pointer, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
-                bpf_map__set_key_size(self.map_pointer, std::mem::size_of::<i32>() as u32);
-                bpf_map__set_value_size(self.map_pointer, std::mem::size_of::<i32>() as u32);
-                BPF_MAP_TYPE_PERF_EVENT_ARRAY
-            } else {
-                BPF_MAP_TYPE_UNSPEC
-            }
-        }
-    }
-    /// open the bpf buffer
-    pub fn bpf_buffer__open(
-        &mut self,
-        sample_callback_wrapper: SampleCallbackWrapper,
-        host_ctx: SampleContext,
-    ) -> i32 {
-        self.host_ctx_box = Some(Box::new(host_ctx));
-        let ctx_ptr = self
-            .host_ctx_box
-            .as_ref()
-            .map(|v| &**v as *const SampleContext as *mut c_void)
-            .unwrap();
-        let ty = self.get_buffer_map_type();
-        let inner = match ty {
-            BPF_MAP_TYPE_PERF_EVENT_ARRAY => {
-                self.host_sample_fn = Some(sample_callback_wrapper);
-                BufferInnerType::PerfBuf(unsafe {
-                    perf_buffer__new(
-                        bpf_map__fd(self.map_pointer),
-                        PERF_BUFFER_PAGES,
-                        Some(perfbuf_sample_fn),
-                        None,
-                        ctx_ptr,
-                        null(),
-                    )
-                })
-            }
-            BPF_MAP_TYPE_RINGBUF => BufferInnerType::RingBuffer(unsafe {
-                ring_buffer__new(
-                    bpf_map__fd(self.map_pointer),
-                    Some(sample_callback_wrapper),
-                    ctx_ptr,
-                    null(),
-                )
-            }),
-            _ => {
-                return -EINVAL;
-            }
-        };
-        if inner.inner_ptr().is_null() {
+    let object_rc = match caller.data().object_map.get(&program) {
+        Some(v) => v.get_object_rc(),
+        None => {
+            error!("Invalid program handle: {}", program);
             return -1;
         }
-        self.inner = inner;
-        0
+    };
+    let object = object_rc.borrow();
+    let map = if let Some(map) = object.maps_iter().find(|v| v.fd() == fd) {
+        map
+    } else {
+        error!("No map with fd {} found!", fd);
+        return -ENOENT;
+    };
+    let object = ensure_program_mut_by_caller!(caller, program);
+    if object.poll_buffer.is_none() {
+        // Create the poller if it's not created
+        let result_recv = Rc::new(RefCell::new(Some(Vec::<u8>::new())));
+        let poll_impl = match map.map_type() {
+            MapType::PerfEventArray => {
+                let local_cb = {
+                    let result_recv = result_recv.clone();
+                    Box::new(move |_cpu: i32, data: &[u8]| {
+                        result_recv.borrow_mut().replace(data.to_vec());
+                    })
+                };
+                let perf_buffer = PerfBufferContainerTryBuilder {
+                    callback_func: local_cb,
+                    perfbuf_builder: |v| PerfBufferBuilder::new(map).sample_cb(v).build(),
+                }
+                .try_build();
+                let perf_buffer = match perf_buffer {
+                    Err(e) => {
+                        error!("Failed to build perfbuffer: {}", e);
+                        return 1;
+                    }
+                    Ok(v) => v,
+                };
+                PollBuffer {
+                    inner: PollBufferImpl::PerfEvent(perf_buffer),
+                    result_container: result_recv,
+                }
+            }
+            MapType::RingBuf => {
+                let local_cb = {
+                    let result_recv = result_recv.clone();
+                    Box::new(move |data: &[u8]| -> i32 {
+                        result_recv.borrow_mut().replace(data.to_vec());
+                        0
+                    })
+                };
+                let ring_buffer: Result<_> = RingBufferContainerTryBuilder {
+                    callback_func: local_cb,
+                    ringbuf_builder: |v| {
+                        let mut ringbuf = RingBufferBuilder::new();
+                        ringbuf
+                            .add(map, v)
+                            .map_err(|e| anyhow!("Failed to add callback for ringbuf: {}", e))?;
+                        ringbuf
+                            .build()
+                            .map_err(|e| anyhow!("Failed to build ringbuf: {}", e))
+                    },
+                }
+                .try_build();
+                let ring_buffer = match ring_buffer {
+                    Err(e) => {
+                        error!("Failed to build ringbuffer: {}", e);
+                        return 1;
+                    }
+                    Ok(v) => v,
+                };
+                PollBuffer {
+                    inner: PollBufferImpl::RingBuf(ring_buffer),
+                    result_container: result_recv,
+                }
+            }
+            s => {
+                error!("Unsupported map type for polling: {}", s);
+                return -1;
+            }
+        };
+        object.poll_buffer = Some(poll_impl);
     }
 
-    /// polling the bpf buffer
-    pub fn bpf_buffer__poll(&self, timeout_ms: i32) -> i32 {
-        match self.inner {
-            BufferInnerType::PerfBuf(s) => unsafe { perf_buffer__poll(s, timeout_ms) },
-            BufferInnerType::RingBuffer(s) => unsafe { ring_buffer__poll(s, timeout_ms) },
-            BufferInnerType::Unsupported => -EINVAL,
+    let result_container = {
+        let poller = object.poll_buffer.as_ref().unwrap();
+        // Clean result
+        poller.result_container.borrow_mut().take();
+        match &poller.inner {
+            PollBufferImpl::RingBuf(rb) => {
+                if let Err(e) = rb
+                    .borrow_ringbuf()
+                    .poll(Duration::from_millis(timeout_ms as u64))
+                {
+                    error!("Failed to poll ringbuf: {}", e);
+                    return -1;
+                }
+            }
+            PollBufferImpl::PerfEvent(perf) => {
+                if let Err(e) = perf
+                    .borrow_perfbuf()
+                    .poll(Duration::from_millis(timeout_ms as u64))
+                {
+                    error!("Failed to poll perf event: {}", e);
+                    return -1;
+                }
+            }
+        }
+        poller.result_container.clone()
+    };
+    // Here we could try to extract the result
+    if let Some(v) = result_container.borrow_mut().take() {
+        let memory = match caller.get_memory() {
+            Err(e) => {
+                error!("Failed to get exported memory: {}", e);
+                return -1;
+            }
+            Ok(v) => v,
+        };
+        let bytes_to_write = v.len().min(max_size as usize);
+        if let Err(e) = memory.write(&mut caller, data as usize, &v[..bytes_to_write]) {
+            error!("Failed to write wasm memory: {}", e);
+            return -1;
+        }
+        // Call the callback
+        if caller.data().wrapper_called {
+            let mut result = [Val::I32(0)];
+            let callback = caller.data().callback_func_name.clone();
+            if let Err(err) = caller
+                .get_export(&callback)
+                .unwrap()
+                .into_func()
+                .unwrap()
+                .call(
+                    &mut caller,
+                    &[
+                        // Seems that tinygo cannot produce unsigned integer types, so just let wasmtiime to perform the conversion
+                        Val::I32(ctx as i32),
+                        Val::I32(data as i32),
+                        Val::I32(bytes_to_write as i32),
+                    ],
+                    &mut result,
+                )
+            {
+                error!("Failed to call the callback through direct export: {}", err);
+                return -1;
+            }
+        } else {
+            match caller.perform_indirect_call::<SampleCallbackParams, SampleCallbackReturn>(
+                sample_func,
+                (ctx, data, bytes_to_write as u32),
+            ) {
+                Ok(v) => {
+                    return v;
+                }
+                Err(e) => {
+                    error!(
+                        "Failed to perform indirect call when polling: {} ; {}\n{}",
+                        e.to_string(),
+                        e.root_cause(),
+                        e.backtrace()
+                    );
+                    return 0;
+                }
+            }
         }
     }
-}
-
-impl Drop for BpfBuffer {
-    fn drop(&mut self) {
-        match self.inner {
-            BufferInnerType::PerfBuf(s) => unsafe {
-                perf_buffer__free(s);
-            },
-            BufferInnerType::RingBuffer(s) => unsafe { ring_buffer__free(s) },
-            BufferInnerType::Unsupported => {}
-        }
-    }
-}
-
-extern "C" fn perfbuf_sample_fn(ctx: *mut c_void, _cpu: i32, data: *mut c_void, size: u32) {
-    sample_function_wrapper(ctx, data, size as u64);
+    0
 }

--- a/runtime/wasm-bpf-rs/src/state.rs
+++ b/runtime/wasm-bpf-rs/src/state.rs
@@ -116,4 +116,4 @@ impl AppState {
     }
 }
 
-pub type CallerType<'a> = Caller<'a, AppState>;
+pub(crate) type CallerType<'a> = Caller<'a, AppState>;

--- a/runtime/wasm-bpf-rs/src/state.rs
+++ b/runtime/wasm-bpf-rs/src/state.rs
@@ -3,52 +3,101 @@
 //! Copyright (c) 2023, eunomia-bpf
 //! All rights reserved.
 //!
-use std::{collections::HashMap, fs::File, ptr::null, sync::mpsc};
-
-use libbpf_rs::{
-    libbpf_sys::{self, bpf_map, bpf_map__fd, bpf_object__next_map},
-    Link, Map, Object, Program,
+use std::{
+    cell::{Ref, RefCell, RefMut},
+    collections::HashMap,
+    fs::File,
+    rc::Rc,
+    sync::mpsc,
 };
+
+use libbpf_rs::{Link, Object, PerfBuffer, RingBuffer};
 use wasmtime::Caller;
 use wasmtime_wasi::WasiCtx;
 
-use crate::{bpf::poll::BpfBuffer, handle::ProgramOperation};
+use crate::handle::ProgramOperation;
 
+use ouroboros::self_referencing;
 const FIRST_OBJECT_ID: u64 = 1;
 
+/// The callback of a ringbuffer poller
+pub type RingBufferCallback = Box<dyn Fn(&[u8]) -> i32>;
+#[self_referencing(pub_extras)]
+/// A helper container to hold a RingBuffer and its calback
+pub struct RingBufferContainer {
+    /// The callback
+    pub callback_func: RingBufferCallback,
+    #[borrows(callback_func)]
+    #[covariant]
+    /// The ringbuf
+    pub ringbuf: RingBuffer<'this>,
+}
+/// The callback of a perfbuffer poller
+pub type PerfBufferSampleCallback = Box<dyn Fn(i32, &[u8])>;
+#[self_referencing(pub_extras)]
+/// A helper container to hold a perfbuffer and its callback
+pub struct PerfBufferContainer {
+    /// The callback
+    pub callback_func: PerfBufferSampleCallback,
+    #[borrows(callback_func)]
+    #[covariant]
+    /// The perfbuffer
+    pub perfbuf: PerfBuffer<'this>,
+}
+/// The enum to hold two kinds of poller
+pub enum PollBufferImpl {
+    /// The ringbuf
+    RingBuf(RingBufferContainer),
+    /// The perfevent
+    PerfEvent(PerfBufferContainer),
+}
+/// The container of a poller implementation and its result container
+/// The result container will be used to store the result that the sampling callback receives
+/// since it's a shared Rc, so we can write the result in the callback regardless of the ownership
+pub struct PollBuffer {
+    /// The implementation
+    pub inner: PollBufferImpl,
+    /// The result container
+    pub result_container: Rc<RefCell<Option<Vec<u8>>>>,
+}
+/// A `Program`, holding a bpf Object and a poller
 pub struct WrapperObject {
-    pub object: Object,
-    pub buffer: Option<BpfBuffer>,
+    // Put Object in a Rc<RefCell<T>> to avoid holding a reference to WrapperObject
+    /// The ebpf Object
+    pub object: Rc<RefCell<Object>>,
+    /// The poller; It will be set when the first time to call the sampling function
+    pub poll_buffer: Option<PollBuffer>,
 }
 
 impl WrapperObject {
-    pub fn get_object(&self) -> &Object {
-        &self.object
+    /// Get a reference pointer to the EbpfObject
+    pub fn get_object_rc(&self) -> Rc<RefCell<Object>> {
+        self.object.clone()
     }
-    pub fn get_object_mut(&mut self) -> &mut Object {
-        &mut self.object
+    /// Get a reference to the Object
+    pub fn get_object(&self) -> Ref<Object> {
+        self.object.borrow()
+    }
+    /// Get a mutable reference to the Object
+    pub fn get_object_mut(&self) -> RefMut<Object> {
+        self.object.borrow_mut()
     }
 }
 
+/// The application state
 pub struct AppState {
-    pub wasi: WasiCtx,
-    pub next_object_id: u64,
-    pub object_map: HashMap<u64, WrapperObject>,
-    pub opened_files: Vec<File>,
-    pub opened_links: Vec<Link>,
-    pub callback_func_name: String,
-    pub wrapper_called: bool,
-    pub operation_rx: mpsc::Receiver<ProgramOperation>,
-}
-
-#[allow(unused)]
-struct MyObject {
-    pub ptr: *mut libbpf_sys::bpf_object,
-    _maps: HashMap<String, Map>,
-    _progs: HashMap<String, Program>,
+    pub(crate) wasi: WasiCtx,
+    pub(crate) next_object_id: u64,
+    pub(crate) object_map: HashMap<u64, WrapperObject>,
+    pub(crate) opened_files: Vec<File>,
+    pub(crate) opened_links: Vec<Link>,
+    pub(crate) callback_func_name: String,
+    pub(crate) wrapper_called: bool,
+    pub(crate) operation_rx: mpsc::Receiver<ProgramOperation>,
 }
 
 impl AppState {
+    /// Create an AppState
     pub fn new(
         wasi: WasiCtx,
         callback_func_name: String,
@@ -64,22 +113,6 @@ impl AppState {
             wrapper_called: false,
             operation_rx,
         }
-    }
-    pub fn get_map_ptr_by_fd(&self, fd: i32) -> Option<*const bpf_map> {
-        for prog in self.object_map.values() {
-            unsafe {
-                let ptr = prog.get_object() as *const Object as *const MyObject;
-                let bpf_object_ptr = (*ptr).ptr;
-                let mut pos = bpf_object__next_map(bpf_object_ptr, null());
-                while !pos.is_null() {
-                    if bpf_map__fd(pos) == fd {
-                        return Some(pos);
-                    }
-                    pos = bpf_object__next_map(bpf_object_ptr, pos);
-                }
-            }
-        }
-        None
     }
 }
 


### PR DESCRIPTION
This PR closes #92 .

It uses new features (such as MapInfo) in libbpf-rs, which was used to replace old FFI calls.

Besides, It also uses `PerfBuffer` and `RingBuffer` in `libbpf-rs` to implement buffer polling. In this feature we use some tricks, see  the doc of `PollBuffer` for details. In a nut shell, I wrap the `PerfBuffer` and `RingBuffer` along with its Boxed callback to a self-referencing container to resolve ownership problems. Besides, I use a `Rc<RefCell<Option<Vec<u8>>>>` to send result from the callback, thus the callback won't reference or capture the `Caller<'a>`, and we can examine the result container (The `Rc<...>` mentioned) to get the result that the callback receives and call the wasm callback safely.

Currently only `wasm_bpf_map_operate` uses FFI calls, since `libbpf-rs` haven't give us API to operate a map by file descriptor.
