### PR TITLE
fix terminating issue (again)

### DIFF
--- a/runtime/wasm-bpf-rs/Cargo.toml
+++ b/runtime/wasm-bpf-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-bpf-rs"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "MIT"
 description = "A WebAssembly runtime library for eBPF programs based on libbpf and wasmtime"

--- a/runtime/wasm-bpf-rs/src/handle.rs
+++ b/runtime/wasm-bpf-rs/src/handle.rs
@@ -51,7 +51,7 @@ impl WasmProgramHandle {
     }
     /// Terminate the wasm program
     /// Error will be returned when the program was already terminated
-    pub fn terminate(&mut self) -> anyhow::Result<()> {
+    pub fn terminate(self) -> anyhow::Result<()> {
         debug!("Terminating wasm program");
         self.engine.increment_epoch();
         self.operation_tx

--- a/runtime/wasm-bpf-rs/src/tests/mod.rs
+++ b/runtime/wasm-bpf-rs/src/tests/mod.rs
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 use std::thread;
 use std::time::Duration;
 
-// This function is only needed when running tests, so I put it here.
+/// This function is only needed when running tests, so I put it here.
 pub fn get_test_file_path(name: impl AsRef<str>) -> PathBuf {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("tests");
@@ -39,8 +39,7 @@ fn test_example_and_wait(name: &str, config: Config, wait_policy: WaitPolicy) {
         let (wasm_handle, _) = run_wasm_bpf_module_async(&buffer, &args, config).unwrap();
         *handle_out = Some(wasm_handle);
     } else if let WaitPolicy::WaitUntilTimedOut(timeout_sec) = wait_policy {
-        let (wasm_handle, join_handle) =
-            run_wasm_bpf_module_async(&buffer, &args, config).unwrap();
+        let (wasm_handle, join_handle) = run_wasm_bpf_module_async(&buffer, &args, config).unwrap();
         thread::sleep(Duration::from_secs(timeout_sec));
         // What if the wasm programs ends before the timeout_sec? If that happened, terminate will be failing.
         // So there shouldn't be `unwrap`

--- a/runtime/wasm-bpf-rs/src/tests/mod.rs
+++ b/runtime/wasm-bpf-rs/src/tests/mod.rs
@@ -39,7 +39,7 @@ fn test_example_and_wait(name: &str, config: Config, wait_policy: WaitPolicy) {
         let (wasm_handle, _) = run_wasm_bpf_module_async(&buffer, &args, config).unwrap();
         *handle_out = Some(wasm_handle);
     } else if let WaitPolicy::WaitUntilTimedOut(timeout_sec) = wait_policy {
-        let (mut wasm_handle, join_handle) =
+        let (wasm_handle, join_handle) =
             run_wasm_bpf_module_async(&buffer, &args, config).unwrap();
         thread::sleep(Duration::from_secs(timeout_sec));
         // What if the wasm programs ends before the timeout_sec? If that happened, terminate will be failing.
@@ -174,7 +174,7 @@ fn test_pause_and_resume_wasm_program() {
     let tick_count_3 = count_tick();
     println!("Tick count 3: {}", tick_count_3);
     assert!(tick_count_3 - tick_count_2 >= 2);
-    handle.as_mut().unwrap().terminate().unwrap();
+    handle.take().unwrap().terminate().unwrap();
 }
 
 #[test]
@@ -217,7 +217,7 @@ fn test_interruption_in_host_function() {
         tx.send(wasm_handle).unwrap();
         func_wrapper.run().unwrap();
     });
-    let mut handle = rx.recv().unwrap();
+    let handle = rx.recv().unwrap();
     std::thread::sleep(Duration::from_secs(2));
     handle.terminate().unwrap();
 }
@@ -226,7 +226,7 @@ fn test_interruption_in_host_function() {
 fn test_interruption_in_wasm_callback() {
     let module_binary = std::fs::read(get_test_file_path("interruption_in_callback.wasm")).unwrap();
     let args = vec!["test".to_string()];
-    let (mut handle, _) =
+    let (handle, _) =
         run_wasm_bpf_module_async(&module_binary[..], &args[..], Config::default()).unwrap();
     std::thread::sleep(Duration::from_secs(2));
     handle.terminate().unwrap();


### PR DESCRIPTION
This PR tries to fix that the terminate function will stuck when trying to terminate a wasm program.

- Now, the `WasmProgramHandle::terminate` will consume self to drop the Sender, which makes the receiver impossible to be stucking at receiving - the dropness of sender will cause any receiving action to fail