### PR TITLE
Add the c wrapper for APIs of `wasm-bpf`

### DIFF
--- a/.github/workflows/build-static-wasm-bpf.yml
+++ b/.github/workflows/build-static-wasm-bpf.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
           cd runtime/c-wrapper
           cargo build --release
-    - name: Combile several archives
+    - name: Merge several archives
       run: |
         cp ./runtime/target/release/libwasm_bpf.a .
         cp /usr/lib/x86_64-linux-gnu/libz.a .

--- a/.github/workflows/build-static-wasm-bpf.yml
+++ b/.github/workflows/build-static-wasm-bpf.yml
@@ -1,0 +1,43 @@
+name: Build the static library of `wasm-bpf`
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
+
+    - name: install deps
+      run: |
+          sudo make install-deps
+
+    - name: Build wasm_bpf
+      run: |
+          cd runtime/c-wrapper
+          cargo build --release
+    - name: Combile several archives
+      run: |
+        cp ./runtime/target/release/libwasm_bpf.a .
+        cp /usr/lib/x86_64-linux-gnu/libz.a .
+        cp /usr/lib/x86_64-linux-gnu/libelf.a .
+        llvm-ar x libwasm_bpf.a
+        llvm-ar x libelf.a
+        llvm-ar x libz.a
+        rm *.a
+        llvm-ar q libwasm_bpf.a *.o
+
+    - name: Upload build result
+      uses: actions/upload-artifact@v2.3.1
+      with:
+        path: "libwasm_bpf.a"

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ clean:
 
 install-deps: ## install deps
 	apt update
-	apt-get install libcurl4-openssl-dev libelf-dev clang llvm pahole -y ## libgtest-dev
+	apt-get install libcurl4-openssl-dev libelf-dev clang llvm pahole zlib1g-dev -y ## libgtest-dev
 
 /opt/wasi-sdk:
 	wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-17/wasi-sdk-17.0-linux.tar.gz

--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.69"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 dependencies = [
  "backtrace",
 ]
@@ -1835,8 +1835,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bpf-c-wrapper"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "wasm-bpf-rs",
+]
+
+[[package]]
 name = "wasm-bpf-rs"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "flexi_logger",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,7 +1,5 @@
 [workspace]
-members = [
-    "cli", "wasm-bpf-rs"
-]
+members = ["cli", "wasm-bpf-rs", "c-wrapper"]
 
 [profile.release]
 opt-level = 3

--- a/runtime/c-wrapper/Cargo.toml
+++ b/runtime/c-wrapper/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "wasm-bpf-c-wrapper"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+name = "wasm_bpf"
+crate-type = ["cdylib", "staticlib"]
+
+[dependencies]
+anyhow = "1.0.71"
+wasm-bpf-rs = { path = "../wasm-bpf-rs", version = "*" }

--- a/runtime/c-wrapper/src/lib.rs
+++ b/runtime/c-wrapper/src/lib.rs
@@ -1,0 +1,149 @@
+//!  SPDX-License-Identifier: MIT
+//!
+//! Copyright (c) 2023, eunomia-bpf
+//! All rights reserved.
+//!
+
+// Do we really need `unsafe` on FFI functions? I don't think :)
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
+
+use std::{
+    ffi::{c_char, c_int, c_ulonglong, CStr},
+    slice,
+    thread::JoinHandle,
+};
+
+use wasm_bpf_rs::{handle::WasmProgramHandle, Config};
+unsafe fn dump_strings_from_argv(argv: *const *const c_char, argc: c_int) -> Vec<String> {
+    let mut args_vec = vec![];
+    for i in 0..argc {
+        let curr = { *argv.offset(i as isize) };
+        let curr = { CStr::from_ptr(curr) }.to_string_lossy().to_string();
+        args_vec.push(curr);
+    }
+    args_vec
+}
+
+#[no_mangle]
+/// Run a module sync
+/// error_callback will be called if any error happened
+pub extern "C" fn wasm_bpf_module_run(
+    module_binary: *const u8,
+    module_binary_size: c_ulonglong,
+    argv: *const *const c_char,
+    argc: c_int,
+    error_callback: Option<unsafe extern "C" fn(*const c_char)>,
+) -> i32 {
+    let module_binary =
+        unsafe { slice::from_raw_parts(module_binary, module_binary_size as usize) };
+    let args_vec = unsafe { dump_strings_from_argv(argv, argc) };
+    if let Err(e) = wasm_bpf_rs::run_wasm_bpf_module(module_binary, &args_vec, Config::default()) {
+        if let Some(cb) = error_callback {
+            let ptr = e.to_string().as_ptr() as *const c_char;
+
+            unsafe { cb(ptr) };
+        }
+        return -1;
+    }
+    0
+}
+
+#[no_mangle]
+/// Run a module async
+/// error_callback will be called if any error happened
+/// returns a handle to control the program, if succeeded; else returns null
+pub extern "C" fn wasm_bpf_module_run_async(
+    module_binary: *const u8,
+    module_binary_size: c_ulonglong,
+    argv: *const *const c_char,
+    argc: c_int,
+    error_callback: Option<unsafe extern "C" fn(*const c_char)>,
+) -> Option<Box<WrappedHandle>> {
+    let module_binary =
+        unsafe { slice::from_raw_parts(module_binary, module_binary_size as usize) };
+    let args_vec = unsafe { dump_strings_from_argv(argv, argc) };
+    let (prog_hd, join_hd) =
+        match wasm_bpf_rs::run_wasm_bpf_module_async(module_binary, &args_vec, Config::default()) {
+            Ok(v) => v,
+            Err(e) => {
+                if let Some(cb) = error_callback {
+                    let ptr = e.to_string().as_ptr() as *const c_char;
+
+                    unsafe { cb(ptr) };
+                }
+                return None;
+            }
+        };
+    Some(Box::new(WrappedHandle {
+        prog_handle: Some(prog_hd),
+        join_handle: Some(join_hd),
+    }))
+}
+
+#[repr(C)]
+/// A wrapped handle
+pub struct WrappedHandle {
+    prog_handle: Option<WasmProgramHandle>,
+    join_handle: Option<JoinHandle<anyhow::Result<()>>>,
+}
+#[no_mangle]
+/// Destroy the handle
+/// Destroying the handle will not terminate the running program
+pub extern "C" fn wasm_bpf_handle_destroy(handle: Box<WrappedHandle>) {
+    drop(handle);
+}
+#[no_mangle]
+/// Pause the program
+pub extern "C" fn wasm_bpf_handle_pause_prog(handle: *mut WrappedHandle) -> i32 {
+    let handle = unsafe { &mut *handle };
+    if let Some(hd) = &mut handle.prog_handle {
+        if hd.pause().is_err() {
+            return -1;
+        }
+    } else {
+        return -1;
+    }
+    0
+}
+
+#[no_mangle]
+/// Resume the program
+pub extern "C" fn wasm_bpf_handle_resume_prog(handle: *mut WrappedHandle) -> i32 {
+    let handle = unsafe { &mut *handle };
+    if let Some(hd) = &mut handle.prog_handle {
+        if  hd.resume().is_err() {
+            return -1;
+        }
+    } else {
+        return -2;
+    }
+    0
+}
+
+#[no_mangle]
+/// Terminate the program
+pub extern "C" fn wasm_bpf_handle_terminate_prog(handle: *mut WrappedHandle) -> i32 {
+    let handle = unsafe { &mut *handle };
+    if let Some(hd) = handle.prog_handle.take() {
+        if hd.terminate().is_err() {
+            return -1;
+        }
+    } else {
+        return -2;
+    }
+    0
+}
+
+#[no_mangle]
+/// Wait for the program's exiting
+pub extern "C" fn wasm_bpf_handle_join_prog(handle: *mut WrappedHandle) -> i32 {
+    let handle = unsafe { &mut *handle };
+    if let Some(hd) = handle.join_handle.take() {
+        if hd.join().is_err() {
+            return -1;
+        }
+    } else {
+        return -2;
+    }
+    0
+}


### PR DESCRIPTION
Closes #111 

This PR adds a new crate `wasm-bpf-c-wrapper` for the `wasm-bpf`, and exposes its APIs as C interfaces.

It contains six functions:
- `wasm_bpf_module_run`: Same as the rust one. But use an optional callback function to accept error message
- `wasm_bpf_module_run_async`: Same as above. And it returns a pointer to the handle. The handle should be destroyed use wasm_bpf_handle_destroy
- `wasm_bpf_handle_pause_prog`, `wasm_bpf_handle_resume_prog`, `wasm_bpf_handle_terminate_prog`, `wasm_bpf_handle_join_prog`. It's easy to understand their behaviors.

It also adds a workflow to produce static library for `wasm-bpf`, including `libelf` and `libz`. With this we can produce standalone executables with ecc.