### PR TITLE
ci: remove unavailable Nix cache

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -16,10 +16,6 @@ jobs:
           experimental-features = nix-command flakes
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
-    - uses: cachix/cachix-action@v12
-      with:
-        name: zeek
-
     - name: Nix Flake Show
       run: nix flake show --all-systems
 


### PR DESCRIPTION
## Summary

Remove the optional `zeek` Cachix setup from the Nix workflow. The cache no longer exists publicly (or is private without a token), so both dependency PRs fail before `nix flake show`, `nix develop`, or `nix build` can run. The flake uses public inputs and does not require this cache for correctness.

## Validation

- `git diff --check`
- workflow YAML parsed successfully
- local Nix execution is unavailable on this host; the PR workflow is the authoritative run for the three existing Nix commands

Unblocks #155 and #156.